### PR TITLE
adhere to padded-blocks

### DIFF
--- a/client/views/home.js
+++ b/client/views/home.js
@@ -1,7 +1,6 @@
 /* global $ */
 module.exports = function () {
   $(document).ready(function () {
-
     setTimeout(function () {
       $('#pre').fadeOut(600)
     }, 300)


### PR DESCRIPTION
We are in the process of adding back the rule `padded-blocks` into `standard`. It was temporarily disabled because of a bug in eslint which now has been fixed.

This pull request makes sure that your coding style is compliant with the new version.

Please see feross/standard#170 for more info.