### PR TITLE
Add βTorrent to the apps and clients lists

### DIFF
--- a/server/views/faq.jade
+++ b/server/views/faq.jade
@@ -70,6 +70,7 @@ block body
       - **[Fastcast][fastcast]** – Gallery site with some videos ([source code](https://github.com/jakefb/fastcast))
       - **[Colored Coins][coloredcoins]** - Open protocol for creating digital assets on the Bitcoin blockchain ([source code](https://github.com/Colored-Coins/Metadata-Handler))
       - **[Tokenly Pockets][pockets]** - Digital token issuance with WebTorrent-based metadata ([source code][pockets-source])
+      - **[βTorrent][btorrent]** - Fully-featured AngularJS WebTorrent client ([source code][btorrent-source])
       - *Your app here – [Send a PR][pr] with your URL!*
 
       [instant.io-source]: https://github.com/feross/instant.io
@@ -83,6 +84,8 @@ block body
       [coloredcoins]: http://coloredcoins.org
       [pockets]: http://pockets.tokenly.com/
       [pockets-source]: https://github.com/loon3/Tokenly-Pockets
+      [btorrent]: https://btorrent.xyz
+      [btorrent-source]: https://github.com/DiegoRBaquero/bTorrent
 
       ## How does WebTorrent work?
 
@@ -175,6 +178,7 @@ block body
       - [Playback][playback] - Open source JavaScript video player **(super cool!)**
       - [Instant.io][instant.io] - Simple WebTorrent client in a website
       - [`webtorrent-hybrid`][webtorrent-hybrid] - Node.js package (command line and API)
+      - [βTorrent][btorrent] - Fully-featured AngularJS WebTorrent client ([source code][btorrent-source])
       - *More coming soon – [Send a PR][pr] to add your client to the list!*
 
       In node.js, `webtorrent-hybrid` can download torrents from WebRTC peers or TCP peers


### PR DESCRIPTION
βTorrent is an open source AngularJS client in the browser and I'm working on an electron-based app.