### PR TITLE
Fixes padding issue

### DIFF
--- a/client/style.styl
+++ b/client/style.styl
@@ -481,7 +481,7 @@ body.is-seed .show-leech
     width: 160px
     height: 130px
     margin: 15px
-    padding: 20px 30px
+    padding: 20px 15px
     border: none
     border-radius: 5px
     cursor: pointer


### PR DESCRIPTION
Came across this earlier when browsing the webtorrent desktop page:
![2016-06-09-180027_661x586_scrot](https://cloud.githubusercontent.com/assets/14895856/15951345/624c46ce-2e6c-11e6-98f5-59d7c17fafce.png)

I believe what was intended was:
![2016-06-09-180044_790x587_scrot](https://cloud.githubusercontent.com/assets/14895856/15951348/69696d56-2e6c-11e6-970b-b8ff80f085cc.png)

Edit: The problem seems to be browser specific as I use iceweasel. On most other devices it may render normally. Either way, the proposed PR shouldn't affect what currently works.