### PR TITLE
Add button to start demo.

### DIFF
--- a/client/style.styl
+++ b/client/style.styl
@@ -314,10 +314,7 @@ article
 
 #hero
   background-color: BLUE
-
-  @media DESKTOP
-    height: HERO_HEIGHT
-    margin: 0 auto
+  text-align: center
 
   .is-seed &
     background-color: DARK_GREEN
@@ -326,12 +323,29 @@ article
   h1
     color: white
     text-align: center
-    margin: 0 0 -60px 0
+    margin: 0
     padding-top: 30px
     line-height: 1
 
     em
       border-bottom: 6px solid rgba(255, 255, 255, 0.2)
+
+  #progressBar, #status, #svgWrap, #videoWrap
+    display: none
+
+  #begin
+    margin: 20px auto
+
+#hero.loading
+  @media DESKTOP
+    height: HERO_HEIGHT
+    margin: 0 auto
+
+  #progressBar, #status, #svgWrap, #videoWrap
+    display: block
+
+  h1
+    margin-bottom: -60px
 
 #svgWrap
   width: 100%

--- a/client/views/home.js
+++ b/client/views/home.js
@@ -13,12 +13,41 @@ var TORRENT = fs.readFileSync(
 )
 
 module.exports = function () {
-  var graph = window.graph = new TorrentGraph('.torrent-graph')
+  var graph
+  var hero = document.querySelector('#hero')
 
-  getRtcConfig('https://instant.io/rtcConfig', function (err, rtcConfig) {
-    if (err) console.error(err)
-    createClient(rtcConfig)
-  })
+  // Don't start the demo automatically on mobile.
+  if (window.innerWidth <= 899) {
+    var beginButton = document.createElement('a')
+    beginButton.href = '#'
+    beginButton.id = 'begin'
+    beginButton.className = 'btn large'
+    beginButton.textContent = 'Begin Demo'
+
+    beginButton.addEventListener('click', function onClick () {
+      beginButton.removeEventListener('click', onClick, false)
+      beginButton.parentNode.removeChild(beginButton)
+      beginButton = null
+
+      init()
+    })
+    hero.appendChild(beginButton)
+  } else {
+    init()
+  }
+
+  function init () {
+    // Display video and related information.
+    hero.className = 'loading'
+    hero = null
+
+    graph = window.graph = new TorrentGraph('.torrent-graph')
+
+    getRtcConfig('https://instant.io/rtcConfig', function (err, rtcConfig) {
+      if (err) console.error(err)
+      createClient(rtcConfig)
+    })
+  }
 
   var torrent
   function createClient (rtcConfig) {


### PR DESCRIPTION
Prevents demo from being started by default on mobile, which can cause over-usage of bandwidth.

Ref. #40, #58.