### PR TITLE
Telemetry: latest-version errors, fix retention calculation

### DIFF
--- a/bin/summarize-telemetry.js
+++ b/bin/summarize-telemetry.js
@@ -161,14 +161,25 @@ function addToSet (elem, arr, sortFn) {
 
 // Combine all the per-day summaries into a single summary...
 function combineDailyTelemetrySummaries (days) {
-  var uniqueUsers = {}
+  var uniqueUsers = {} // Running set, all unique users so far
+  var newUsersByDay = [] // First-time users each day
+
+  // Loop thru all days since we started collecting telemetry...
   return days.map(function (day, i) {
-    var numUsersYesterday = Object.keys(uniqueUsers).length
-    Object.assign(uniqueUsers, day.uniqueUsers)
-    var numInstalls = Object.keys(uniqueUsers).length - numUsersYesterday
+    // Find out who installed the app that day
+    var newUsers = {}
+    Object.keys(day.uniqueUsers).forEach(function (user) {
+      if (uniqueUsers[user]) return
+      uniqueUsers[user] = true
+      newUsers[user] = true
+    })
+    var numInstalls = Object.keys(newUsers).length
+    newUsersByDay[i] = newUsers
+
     var errors = Object.keys(day.errors)
       .map((key) => day.errors[key])
       .sort((a, b) => b.count - a.count)
+
     return {
       date: day.date,
       actives: {
@@ -178,9 +189,9 @@ function combineDailyTelemetrySummaries (days) {
       },
       installs: numInstalls,
       retention: {
-        day1: i < 1 ? null : computeRetention(day, days[i - 1]),
-        day7: i < 7 ? null : computeRetention(day, days[i - 7]),
-        day28: i < 28 ? null : computeRetention(day, days[i - 28])
+        day1: i < 2 ? null : computeRetention(day, newUsersByDay[i - 1]),
+        day7: i < 8 ? null : computeRetention(day, newUsersByDay[i - 7]),
+        day28: i < 29 ? null : computeRetention(day, newUsersByDay[i - 28])
       },
       usage: day.usage,
       errorRates: {
@@ -236,11 +247,11 @@ function computeActives (days, index, n) {
 
 // Computes retention: the # of new users from some past day that used the
 // app on this day.
-function computeRetention (day, prevDay) {
-  var combined = Object.assign({}, day.uniqueUsers, prevDay.uniqueUsers)
+function computeRetention (day, prevNewUsers) {
+  var combined = Object.assign({}, day.uniqueUsers, prevNewUsers)
   var numCombined = Object.keys(combined).length
   var numToday = Object.keys(day.uniqueUsers).length
-  var numPrev = Object.keys(prevDay.uniqueUsers).length
+  var numPrev = Object.keys(prevNewUsers).length
   var numLost = numCombined - numToday
   return (numPrev - numLost) / numPrev
 }

--- a/client/style.styl
+++ b/client/style.styl
@@ -672,6 +672,10 @@ body.is-seed .show-leech
 .telemetry-dashboard svg g.nv-axisMax-x text
   transform: translateX(-12px)
 
+.telemetry-dashboard input
+  margin: 0 10px 0 0
+  font-size: 18px
+
 .error-header
   font-weight: bold
 
@@ -712,6 +716,12 @@ body.is-seed .show-leech
   overflow: hidden
 
 .error-stacktrace.visible
+  display: block
+
+.error-list
+  display: none
+
+.error-list.visible
   display: block
 
 @import '../node_modules/highlight.js/styles/zenburn.css'

--- a/server/desktop-api.js
+++ b/server/desktop-api.js
@@ -121,11 +121,20 @@ function serveTelemetryDashboard (req, res, next) {
         : '-'
 
       // Most common errors
+      var latestVersion = versions[versions.length - 1]
       var mostCommonErrorsDate = yesterday ? yesterday.date : '-'
-      var mostCommonErrors = yesterday ? yesterday.errors : []
-      mostCommonErrors.forEach(function (err) {
-        err.stack = err.stack.replace(/\(.*app.asar/g, '(...')
-      })
+      var allErrors = (yesterday ? yesterday.errors : [])
+        .map(function (err) {
+          err.stack = err.stack.replace(/\(.*app.asar/g, '(...')
+          return err
+        })
+      var mostCommonErrors = {
+        all: allErrors.slice(0, 10),
+        latest: allErrors.filter(function (err) {
+          return err.versions.includes(latestVersion)
+        }).slice(0, 10)
+      }
+      console.log('Latest version: ' + latestVersion)
 
       res.render('telemetry-dashboard', {
         filesByMonth,
@@ -133,7 +142,8 @@ function serveTelemetryDashboard (req, res, next) {
         percentWeeklyGrowth,
         mostCommonErrors,
         mostCommonErrorsDate,
-        versions
+        versions,
+        latestVersion
       })
     })
   })

--- a/server/views/telemetry-dashboard.pug
+++ b/server/views/telemetry-dashboard.pug
@@ -20,7 +20,7 @@ block body
       p Calculated by dividing the number of users in the last 7 days by the previous 7 days. Target: 5+%
       p
         strong Total installs: #{summary.totalInstalls.total.toLocaleString()}.
-        |  Windows: #{summary.totalInstalls.win32.toLocaleString()} Mac: #{summary.totalInstalls.darwin.toLocaleString()} Linux: #{summary.totalInstalls.linux.toLocaleString()}
+        | Windows: #{summary.totalInstalls.win32.toLocaleString()} Mac: #{summary.totalInstalls.darwin.toLocaleString()} Linux: #{summary.totalInstalls.linux.toLocaleString()}
 
     section
       h3 Installs
@@ -41,20 +41,27 @@ block body
     section
       h3 Most common errors on #{mostCommonErrorsDate}
       p Errors are aggregated by the first 30 characters of the message, highlighted in green. Click on any error to see an example stacktrace.
+      p
+        input(type='checkbox', id='latest-only', checked='checked')
+        label(for='latest-only') Show errors that occur in the latest version (#{latestVersion}) only
       div.error-header
         span.error-count Count
         span.error-message Example message
-      each error in mostCommonErrors
-        div.error-row
-          div.error-summary
-            span.error-count #{error.count}
-            span.error-message
-              span.error-message-key #{error.key}
-              span.error-message-rest #{error.message.substring(error.key.length)}
-          if error.stack
-            div.error-stacktrace #{error.stack}
-          else
-            div.error-stacktrace No stack trace
+      each errVersion in ['latest', 'all']
+        div.error-list(id=('errors-' + errVersion))
+          each error in mostCommonErrors[errVersion]
+            div.error-row
+              div.error-summary
+                span.error-count #{error.count}
+                span.error-message
+                  span.error-message-key #{error.key}
+                  span.error-message-rest #{error.message.substring(error.key.length)}
+              div.error-stacktrace Versions: #{error.versions.join(' ')}, platforms: #{error.platforms.join(' ')}
+                |<br />
+                if error.stack
+                  |#{error.stack}
+                else
+                  |No stack trace
 
     h2 Usage
     section

--- a/server/views/telemetry-dashboard.pug
+++ b/server/views/telemetry-dashboard.pug
@@ -20,7 +20,7 @@ block body
       p Calculated by dividing the number of users in the last 7 days by the previous 7 days. Target: 5+%
       p
         strong Total installs: #{summary.totalInstalls.total.toLocaleString()}.
-        | Windows: #{summary.totalInstalls.win32.toLocaleString()} Mac: #{summary.totalInstalls.darwin.toLocaleString()} Linux: #{summary.totalInstalls.linux.toLocaleString()}
+        |  Windows: #{summary.totalInstalls.win32.toLocaleString()} Mac: #{summary.totalInstalls.darwin.toLocaleString()} Linux: #{summary.totalInstalls.linux.toLocaleString()}
 
     section
       h3 Installs

--- a/static/desktop/telemetry/script.js
+++ b/static/desktop/telemetry/script.js
@@ -7,43 +7,32 @@ var versions = window.versions
 var telemetry = summary.telemetry.slice(0, summary.telemetry.length - 1)
 var yesterday = telemetry[telemetry.length - 1]
 
-var dataActives = ['today', 'last7', 'last30'].map(function (key) {
-  var values = telemetry.map(function (day) {
+function getValues (fn) {
+  return telemetry.filter(fn).map(function (day) {
     return {
       x: getEndOfDay(day.date),
-      y: day.actives[key]
+      y: fn(day)
     }
   })
+}
+
+var dataActives = ['today', 'last7', 'last30'].map(function (key) {
+  var values = getValues(function (day) { return day.actives[key] })
   return {key, values}
 })
 
 var dataInstalls = [{
   key: 'new users',
-  values: telemetry.map(function (day) {
-    return {
-      x: getEndOfDay(day.date),
-      y: day.installs
-    }
-  })
+  values: getValues(function (day) { return day.installs })
 }]
 
 var dataRetention = ['day1', 'day7', 'day28'].map(function (key) {
-  var values = telemetry.map(function (day) {
-    return {
-      x: getEndOfDay(day.date),
-      y: day.retention[key]
-    }
-  })
+  var values = getValues(function (day) { return day.retention[key] })
   return {key, values}
 })
 
 var dataErrors = ['last7', 'today', 'today-latest'].map(function (key) {
-  var values = telemetry.map(function (day) {
-    return {
-      x: getEndOfDay(day.date),
-      y: day.errorRates[key]
-    }
-  })
+  var values = getValues(function (day) { return day.errorRates[key] })
   return {key, values}
 })
 

--- a/static/desktop/telemetry/script.js
+++ b/static/desktop/telemetry/script.js
@@ -239,6 +239,19 @@ function updateEvents (chart, i) {
 }
 
 // Add event handlers to the errors tables
+var checkbox = document.querySelector('#latest-only')
+checkbox.addEventListener('change', onCheck)
+onCheck()
+function onCheck (e) {
+  document.querySelectorAll('.error-stacktrace').forEach(function (elem) {
+    elem.classList.remove('visible')
+  })
+  var showId = checkbox.checked ? 'errors-latest' : 'errors-all'
+  var hideId = checkbox.checked ? 'errors-all' : 'errors-latest'
+  document.querySelector('#' + showId).classList.add('visible')
+  document.querySelector('#' + hideId).classList.remove('visible')
+}
+
 var rows = document.querySelectorAll('.error-row')
 Array.prototype.forEach.call(rows, function (row) {
   var stackElem = row.querySelector('.error-stacktrace')


### PR DESCRIPTION
## Latest-version errors

<img width="888" alt="screen shot 2016-08-24 at 8 10 19 am" src="https://cloud.githubusercontent.com/assets/169280/17936014/3d1d091e-69d2-11e6-9d8c-4f93a0af92b4.png">

## Retention calculation
Calculate the proportion of users who *installed* n days ago running the app again today, not the proportion of users who *used* the app n days ago running it again today.

### Before (broken)

<img width="880" alt="screen shot 2016-08-24 at 7 56 27 am" src="https://cloud.githubusercontent.com/assets/169280/17936193/d9b99652-69d2-11e6-929c-7faa48800bd9.png">

### After (fixed)

<img width="883" alt="screen shot 2016-08-24 at 8 07 34 am" src="https://cloud.githubusercontent.com/assets/169280/17936059/5cb107a8-69d2-11e6-96fe-4dbf93f9c7b1.png">

The big dip in one-day retention on Aug 21 and 22 is because I broke the default torrents in the 0.11 release. So users who installed the app for the first time, clicked play, and saw the "path missing" error returned the next day at only half the normal rate (~10% vs 20%).

@feross

