### PR TITLE
Google Analytics: track app downloads

### DIFF
--- a/server/views/desktop.pug
+++ b/server/views/desktop.pug
@@ -92,12 +92,6 @@ block body
 
     .feature-block
       article
-        img(src='/img/screenshot-player3.png' alt='WebTorrent Desktop - stream torrents')
-        h1.minimal Give WebTorrent Desktop a try today!
-        include includes/desktop-download-links
-
-    .feature-block
-      article
         h2 Featured Torrents
 
         .feature-item
@@ -137,3 +131,17 @@ block body
           p
             a(href='https://archive.org/details/librivoxaudio') See all free and open source audiobooks
             |  from Librivox, available at the Internet Archive.
+
+    .feature-block
+      article
+        img(src='/img/screenshot-player3.png' alt='WebTorrent Desktop - stream torrents')
+        h1.minimal Give WebTorrent Desktop a try today!
+        include includes/desktop-download-links
+
+  script.
+    document.querySelectorAll('a.download').forEach(function (link) {
+      link.addEventListener('click', function () {
+        console.log('Download link clicked!')
+        window.ga('send', 'event', 'app', 'download')
+      })
+    })


### PR DESCRIPTION
Also moves the second set of download buttons on `/desktop` to the bottom of the page

![screen shot 2016-08-25 at 3 27 44 am](https://cloud.githubusercontent.com/assets/169280/17965938/f3480382-6a73-11e6-9f80-979e7acd2e8b.png)

@feross 